### PR TITLE
Allow custom SSLSocketFactory

### DIFF
--- a/samplecode/java/Naive.java
+++ b/samplecode/java/Naive.java
@@ -13,18 +13,16 @@
  *   implied.  See the License for the specific language governing
  *   permissions and limitations under the License.
  */
-																		
+
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Iterator;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.codec.binary.Base64;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 class Naive {
@@ -135,7 +133,7 @@ class Naive {
 		StringBuilder sb = new StringBuilder();
 		boolean first = true;
 		String encoding = "UTF-8";
-		for (Map.Entry pair : parameters.entrySet()) {
+		for (Map.Entry<?,?> pair : parameters.entrySet()) {
 			String k = pair.getKey().toString();
 			String v = pair.getValue().toString();
 			String current = URLEncoder.encode(k, encoding) + "=" + URLEncoder.encode(v, encoding);

--- a/samplecode/java/com/athenahealth/api/APIConnection.java
+++ b/samplecode/java/com/athenahealth/api/APIConnection.java
@@ -265,6 +265,11 @@ public class APIConnection {
 	        // Join up a url and open a connection
 	        URL url = new URL(path_join(base_url, version, practiceid, path));
 	        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            if(conn instanceof HttpsURLConnection) {
+                SSLSocketFactory ssf = getSSLSocketFactory();
+                if(null != ssf)
+                    ((HttpsURLConnection)conn).setSSLSocketFactory(ssf);
+            }
 	        conn.setRequestMethod(verb);
 
 	        // Set the Authorization header using the token, then do the rest of the headers

--- a/samplecode/java/test/Testing.java
+++ b/samplecode/java/test/Testing.java
@@ -35,6 +35,7 @@ class Testing {
 		String practiceid = "000000";
 		
 		APIConnection api = new APIConnection(version, key, secret, practiceid);
+		api.authenticate();
 		
 		// If you want to set the practice ID after construction, this is how.
 		// api.setPracticeID("000000");


### PR DESCRIPTION
Allow custom SSLSocketFactory. This allows for client-selection of TLS protocol, ciphers, client certificates, and (server) certificate verification.
This requires that the constructor and authenticate() calls are
decoupled.
Remove call to authenticate() from constructor.
