### PR TITLE
Update athenahealthapi.php

### DIFF
--- a/samplecode/php/athenahealthapi.php
+++ b/samplecode/php/athenahealthapi.php
@@ -167,7 +167,7 @@ class APIConnection {
      * @access private
      */
     private function url_join() {
-        return join('/', array_map(function ($p) { return trim($p, '/'); }, func_get_args()));
+        return join('/', array_map(function ($p) { return trim($p, '/'); }, array_filter(func_get_args())));
     }
     
     /**

--- a/samplecode/php/athenahealthapi.php
+++ b/samplecode/php/athenahealthapi.php
@@ -167,7 +167,12 @@ class APIConnection {
      * @access private
      */
     private function url_join() {
-        return join('/', array_map(function ($p) { return trim($p, '/'); }, array_filter(func_get_args())));
+        return join('/', array_map(function ($p) {
+            return trim($p, '/');
+        }, array_filter(func_get_args(), function($value){
+                return ! (is_null($value) || $value == '');
+            }
+        )));
     }
     
     /**


### PR DESCRIPTION
If a null value is passed in, it still adds another / thus leading to a // in the url.

Example: url_join(foo, '', bar) will produce '/foo//bar'
