### PR TITLE
Properly-parse Content-Type response header to remove any parameters.

### DIFF
--- a/samplecode/java/com/athenahealth/api/APIConnection.java
+++ b/samplecode/java/com/athenahealth/api/APIConnection.java
@@ -396,9 +396,17 @@ public class APIConnection {
             if(503 == conn.getResponseCode())
 	            throw new AthenahealthException("Service Temporarily Unavailable: " + rawResponse);
 
-            if(!"application/json".equals(conn.getContentType()))
+            String contentType = conn.getContentType();
+            if(null == contentType)
+                throw new AthenahealthException("Expected application/json response, got <null> instead.");
+
+            int pos = contentType.indexOf(';');
+            if(pos >= 0)
+                contentType = contentType.substring(0, pos).trim();
+
+            if(!"application/json".equals(contentType))
                 throw new AthenahealthException("Expected application/json response, got "
-                                                + conn.getContentType() + " instead."
+                                                + contentType + " instead."
                                                 + " Content=" + rawResponse);
 
 	        // If it won't parse as an object, it'll parse as an array.


### PR DESCRIPTION
This morning, athenaNET started returning HTTP responses with a "charset" parameter to the content-type. That wasn't being properly-handled by APIConnection, and this commit fixes that.